### PR TITLE
style: tutorial 페이지 main 요소 내부 콘텐츠 스타일링

### DIFF
--- a/src/css/pages/pagetutorial.css
+++ b/src/css/pages/pagetutorial.css
@@ -1,22 +1,19 @@
-@import url("../assets/fonts/fonts.css");
+@import url('../assets/fonts/fonts.css');
 
 main {
-  /* padding-top: 110px; */
   color: #444444;
-  font-family: "Pretendard";
+  font-family: 'Pretendard';
   font-size: 16px;
   font-weight: 400;
   letter-spacing: -0.3px;
+  width: 100%;
+  margin-left: 27px;
 }
 
 main p {
-  /* padding-top: 25px; */
-  /* font-weight: 400; */
-  line-height: 27px;
-  text-align: justify;
-  letter-spacing: -0.2px;
-  opacity: 0.7;
-  /* margin-bottom: 10px; */
+  font-size: 18px;
+  line-height: 30px;
+  margin-top: 25px;
 }
 
 img {
@@ -32,38 +29,65 @@ strong {
   font-weight: bold;
 }
 
-ol {
-  padding-left: 0px;
-}
-
 ul {
-  padding-left: 15px;
   list-style: disc;
 }
 
-li {
+.tuto-list {
+  padding-left: 12px;
+}
+
+.tuto-ordered-list-item,
+.tuto-unordered-list-item {
   line-height: 27px;
+  margin-top: 16px;
+  font-size: 18px;
+}
+
+.tuto-unordered-list-item {
+  list-style-position: inside;
+}
+
+.tuto-ordered-list-item:first-child,
+.tuto-unordered-list-item:first-child {
+  margin-top: 0;
 }
 
 /* h2 */
-.tuto-title {
-  padding-bottom: 15px;
-  border-bottom: 1px solid #eeedec;
+.tuto-title-box h2 {
   font-weight: 600;
   font-size: 40px;
-  line-height: 30px;
+  line-height: 1.2;
+  display: inline-block;
+  color: #6d79ee;
+  width: 100%;
+  border-bottom: 1px solid #eeedec;
+}
+
+.tuto-title {
+  font-weight: 600;
+  font-size: 32px;
+  line-height: 1.2;
+  display: inline-block;
+  color: #6d79ee;
 }
 
 /* article 구분선 */
+.tuto-title-box {
+  position: relative;
+  margin-top: 104px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid #eeedec;
+}
+
 .tuto-sec {
   display: flex;
   flex-direction: column;
-  /* gap: 65px; */
-  padding-top: 105px;
-  padding-bottom: 20px;
+  /* temp */
+  padding: 72px 0 119px 0;
 }
 
-.tuto-sec+.tuto-sec {
+.tuto-sec + .tuto-sec {
   border-top: 1px solid #eeedec;
 }
 
@@ -74,12 +98,13 @@ li {
 
 /* h3 */
 .tuto-sec-title {
-  margin-top: 25px;
-  margin-bottom: 15px;
   color: #5966ec;
   font-weight: 600;
-  font-size: 28px;
-  line-height: 30px;
+  font-size: 24px;
+  line-height: 1.2;
+  position: relative;
+  margin-top: 40px;
+  margin-bottom: 20px;
 }
 
 /* h4 */
@@ -99,7 +124,7 @@ li {
   width: 5px;
   height: 29px;
   background: #ffd66c;
-  content: "";
+  content: '';
 }
 
 /* 쿼리문 */
@@ -109,6 +134,7 @@ li {
   background: #f9f9fa;
   border: 1px solid #b4b4b4;
   border-radius: 16px;
+  box-shadow: 1px 1px 5px rgb(0 0 0 / 15%);
 }
 
 .tuto-sec-example-query a {
@@ -119,7 +145,7 @@ li {
 }
 
 .tuto-sec-example-query-para {
-  font-family: "D2Coding";
+  font-family: 'D2Coding';
   font-size: 18px;
   line-height: 180%;
 }
@@ -136,7 +162,17 @@ li {
   color: #ffbb56;
 }
 
-
+.language-sql {
+  font-family: 'D2Coding';
+  font-weight: 700;
+  font-size: 26px;
+  line-height: 35px;
+  line-break: auto;
+  /* temp */
+  word-wrap: break-word;
+  white-space: pre-wrap;
+  word-break: normal;
+}
 /* 
 
 .tuto-sec-cont {

--- a/src/js/parser.js
+++ b/src/js/parser.js
@@ -14,7 +14,8 @@
 
   const codeBlockStart = {
     regex: /^\s*`{3}(.+)/,
-    replace: '<pre class="tuto-sec-example-query"><code>$1',
+    replace:
+      '<pre class="tuto-sec-example-query"><code class="language-sql">$1',
   };
 
   const codeBlockEnd = {
@@ -24,12 +25,12 @@
 
   const unorderedListItem = {
     regex: /^\s*-\s(.+)/,
-    replace: '<li class="test2">$1',
+    replace: '<li class="tuto-unordered-list-item">$1',
   };
 
   const orderedListItem = {
     regex: /^\s*(\d+\.\s.+)/,
-    replace: '<li class="test3">$1',
+    replace: '<li class="tuto-ordered-list-item">$1',
   };
 
   const tableRow = {
@@ -80,9 +81,11 @@
     regex: /^\s*!\[(.*)\]\((.+)\)/,
     replace: (_, g1, g2) => {
       const width = g2.match(/_{2}(\d+)\..+$/)?.[1];
-      return `<figure><img src="${window.location.origin
-        }/pagetutorial/img/${PAGE_NAME}/${g2}"${width ? ` style="width: ${width}px;"` : ''
-        }>${g1 ? `<figcaption>${g1}</figcaption>` : ''}</figure>`;
+      return `<figure><img src="${
+        window.location.origin
+      }/pagetutorial/img/${PAGE_NAME}/${g2}"${
+        width ? ` style="width: ${width}px;"` : ''
+      }>${g1 ? `<figcaption>${g1}</figcaption>` : ''}</figure>`;
     },
   };
 
@@ -180,7 +183,7 @@
             const tagName = rule === unorderedListItem ? 'ul' : 'ol';
             const depth = listDepth(token);
             if (depth > curListDepth) {
-              tokens[i] = `<${tagName} class='test1'>` + tokens[i];
+              tokens[i] = `<${tagName} class='tuto-list'>` + tokens[i];
               listStack.push(`</${tagName}>`);
             } else if (depth < curListDepth) {
               let depthDiff = (curListDepth - depth) / 2;
@@ -308,12 +311,12 @@
   const renderContent = (html) => {
     const div = document.querySelector(`main`);
     const innerHTML = [...html];
-    console.log(html)
+    console.log(html);
     let isFirst = true;
     innerHTML.forEach((token, index) => {
       if (/^<h\d+/.test(token) && token.match(/^<h(\d+)/)[1] === '2') {
         if (isFirst) {
-          innerHTML[index] = '<article class="tuto-sec">' + token;
+          innerHTML[index] = '<article class="tuto-title-box">' + token;
           isFirst = false;
         } else {
           innerHTML[index - 1] += '</article>';


### PR DESCRIPTION
## [ 수정된 파일 ]
  - src/css/pages/pagetutorial.css
  - src/js/parser.js
  
## [ parser.js 수정사항 ]

1. code 요소에 "language-sql" 클래스를 추가하였습니다.

2. ul의 자식 요소인 li에게 "tuto-unordered-list-item" 클래스를 추가하였습니다.

3. ol의 자식 요소인 li에게 "tuto-ordered-list-item" 클래스를 추가하였습니다.

4. ul, ol 요소에 "tuto-list" 클래스를 추가하였습니다.

5. 첫번째 article의 클래스를 "tuto-sec"에서 "tuto-title-box" 클래스로 변경하였습니다.


## [ 노션 페이지 작업사항 ]

1. 코드블록에서 코드 줄바꿈 설정 일괄 적용하였습니다.


## [ 작업 중 발생한 이슈 ]

1. code 요소 안에 들어간 sql 코드 중 쌍따옴표(")로 코드가 묶여있지 않은 경우에는 코드 하단에 줄바꿈이 한번 더 들어갑니다. (ex. 2.11 Like 연산 예제 코드, 2.15 INSERT 연습문제 문제 1번, 문제 2번) => 이 이슈의 발생 원인은 잘 모르겠습니다.

2. 몇 군데에 콘텐츠가 존재하지 않는  <p> 요소가 존재합니다. => 이 이슈를 제거하기 위해서는 노션에서 줄바꿈을 수정하면 해결될 것 같습니다.

3. sql 코드블록 안에 sql syntax highlighting을 주기 위해서는 code 요소 안의 내용들에 span 요소 및 특정 클래스를 넣어줘서 css로 스타일링을 진행하여야 합니다. => 이 이슈는 parser.js 파일에서 작업이 이루어져야할 것 같습니다. 
